### PR TITLE
Fix for Mangum deprecating "enable_lifespan" (issue 44)

### DIFF
--- a/policyguru/main.py
+++ b/policyguru/main.py
@@ -34,4 +34,4 @@ app.include_router(root.router)
 app.include_router(scan_iam_policy.router)
 app.include_router(write_iam_policy.router)
 
-handler = Mangum(app, enable_lifespan=False)
+handler = Mangum(app, lifespan="off")


### PR DESCRIPTION
As mentioned in the issue, Mangum deprecated "enable_lifespan" and replaced it with "lifespan" (references in issue I filed). With the simple switch below, the project now builds/runs as expected on my local Docker test environment.